### PR TITLE
Make it clear that this repository is no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+**This cookbook has been superceded by https://github.com/opscode-cookbooks/php**
+
+
 Description
 ===========
 


### PR DESCRIPTION
I spent quite a while hacking around an issue installing the `pecl_http` extension with this cookbook before a colleague found that this cookbook was in fact a much older version of https://github.com/opscode-cookbooks/php.

I suggest putting some sort of notice at the top of the `README.md` to indicate that that is the case. 
